### PR TITLE
Allow struct like enum variants

### DIFF
--- a/core/src/kind.rs
+++ b/core/src/kind.rs
@@ -1,4 +1,6 @@
+use std::{convert::TryFrom, str::FromStr};
 use strum::{AsRefStr, Display, EnumString};
+
 #[derive(Debug, Display, Clone, Copy, PartialEq, Eq, Hash, AsRefStr, EnumString)]
 pub enum Kind {
     Struct,
@@ -12,5 +14,13 @@ impl quote::ToTokens for Kind {
         use quote::TokenStreamExt;
 
         tokens.append(Ident::new(self.as_ref(), Span::call_site()))
+    }
+}
+
+impl TryFrom<syn::Ident> for Kind {
+    type Error = <Kind as FromStr>::Err;
+
+    fn try_from(value: syn::Ident) -> Result<Self, Self::Error> {
+        value.to_string().parse()
     }
 }

--- a/macro/src/fields.rs
+++ b/macro/src/fields.rs
@@ -4,7 +4,7 @@ use quote::quote;
 use std::collections::HashSet;
 use syn::{spanned::Spanned, Error};
 
-pub fn legal_fields(kind: Kind) -> HashSet<String> {
+fn legal_fields(kind: Kind) -> HashSet<String> {
     match kind {
         Kind::Struct => [
             "attrs",
@@ -48,7 +48,7 @@ pub fn validate_fields(kind: Kind, fields: &syn::FieldsNamed) -> syn::Result<Vec
     Ok(fields.intersection(&legal_fields).cloned().collect())
 }
 
-pub fn construct_fields(used_fields: Vec<String>) -> TokenStream {
+pub fn construct_fields(used_fields: &Vec<String>) -> TokenStream {
     used_fields
         .into_iter()
         .fold(quote!(), |mut construct, field| {

--- a/macro/src/fields.rs
+++ b/macro/src/fields.rs
@@ -1,0 +1,87 @@
+use crate::Kind;
+use proc_macro2::TokenStream;
+use quote::quote;
+use std::collections::HashSet;
+use syn::{spanned::Spanned, Error};
+
+pub fn legal_fields(kind: Kind) -> HashSet<String> {
+    match kind {
+        Kind::Struct => [
+            "attrs",
+            "vis",
+            "struct_token",
+            "ident",
+            "generics",
+            "fields",
+        ],
+        Kind::Enum => [
+            "attrs",
+            "vis",
+            "enum_token",
+            "ident",
+            "generics",
+            "variants",
+        ],
+        Kind::Union => ["attrs", "vis", "union_token", "ident", "generics", "fields"],
+    }
+    .map(String::from)
+    .into()
+}
+
+pub fn validate_fields(kind: Kind, fields: &syn::FieldsNamed) -> syn::Result<Vec<String>> {
+    let legal_fields = legal_fields(kind);
+
+    let fields: HashSet<_> = fields
+        .named
+        .iter()
+        .filter_map(|f| f.ident.as_ref())
+        .map(|f| f.to_string())
+        .collect();
+
+    if let Some(ident) = fields.difference(&legal_fields).next() {
+        return Err(Error::new(
+            ident.span(),
+            format!("Unsupported field `{}`", ident),
+        ));
+    }
+
+    Ok(fields.intersection(&legal_fields).cloned().collect())
+}
+
+pub fn construct_fields(used_fields: Vec<String>) -> TokenStream {
+    used_fields
+        .into_iter()
+        .fold(quote!(), |mut construct, field| {
+            construct.extend(match field.as_str() {
+                "attrs" => quote! {
+                    attrs: ast.attrs,
+                },
+                "vis" => quote! {
+                    vis: ast.vis,
+                },
+                "struct_token" => quote! {
+                    struct_token: s.struct_token,
+                },
+                "enum_token" => quote! {
+                    enum_token: s.enum_token,
+                },
+                "union_token" => quote! {
+                    union_token: s.union_token,
+                },
+                "ident" => quote! {
+                    ident: ast.ident,
+                },
+                "generics" => quote! {
+                    generics: ast.generics,
+                },
+                "fields" => quote! {
+                    fields: s.fields,
+                },
+                "variants" => quote! {
+                    variants: s.variants.into_iter().collect(),
+                },
+                _ => unreachable!(),
+            });
+            construct
+        })
+}

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -2,6 +2,7 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use syn::spanned::Spanned;
 
+mod fields;
 mod multi_derive;
 mod single_derive;
 

--- a/macro/src/multi_derive.rs
+++ b/macro/src/multi_derive.rs
@@ -56,6 +56,9 @@ impl MultiDerive {
                 ));
             }
 
+            //safe to unwrap, invalid cases will return above
+            let kind = var.ident.clone().try_into().unwrap();
+
             match var.fields {
                 syn::Fields::Unnamed(ref fields) => {
                     if fields.unnamed.len() != 1 {
@@ -66,31 +69,12 @@ impl MultiDerive {
                     }
                     let field = fields.unnamed[0].clone();
 
-                    if var.ident == Kind::Struct {
-                        self.support
-                            .insert(Kind::Struct, DeriveVariant::Type(field.ty));
-                    } else if var.ident == Kind::Enum {
-                        self.support
-                            .insert(Kind::Enum, DeriveVariant::Type(field.ty));
-                    } else if var.ident == Kind::Union {
-                        self.support
-                            .insert(Kind::Union, DeriveVariant::Type(field.ty));
-                    }
+                    self.support.insert(kind, DeriveVariant::Type(field.ty));
                 }
                 syn::Fields::Named(ref fields) => {
-                    if var.ident == Kind::Struct {
-                        let used_fields = validate_fields(Kind::Struct, fields)?;
-                        self.support
-                            .insert(Kind::Struct, DeriveVariant::StructLike(used_fields));
-                    } else if var.ident == Kind::Enum {
-                        let used_fields = validate_fields(Kind::Enum, fields)?;
-                        self.support
-                            .insert(Kind::Enum, DeriveVariant::StructLike(used_fields));
-                    } else if var.ident == Kind::Union {
-                        let used_fields = validate_fields(Kind::Union, fields)?;
-                        self.support
-                            .insert(Kind::Union, DeriveVariant::StructLike(used_fields));
-                    }
+                    let used_fields = validate_fields(kind, fields)?;
+                    self.support
+                        .insert(kind, DeriveVariant::StructLike(used_fields));
                 }
                 syn::Fields::Unit => {
                     return Err(Error::new(

--- a/macro/src/single_derive.rs
+++ b/macro/src/single_derive.rs
@@ -1,8 +1,7 @@
-use crate::Kind;
+use crate::{fields, Kind};
 use proc_macro2::TokenStream;
 use quote::quote;
-use std::collections::HashSet;
-use syn::{spanned::Spanned, Error};
+use syn::Error;
 
 pub(crate) struct SingleDerive {
     kind: Kind,
@@ -25,49 +24,9 @@ impl SingleDerive {
         }
     }
 
-    fn legal_fields(&mut self) -> HashSet<String> {
-        match self.kind {
-            Kind::Struct => [
-                "attrs",
-                "vis",
-                "struct_token",
-                "ident",
-                "generics",
-                "fields",
-            ],
-            Kind::Enum => [
-                "attrs",
-                "vis",
-                "enum_token",
-                "ident",
-                "generics",
-                "variants",
-            ],
-            Kind::Union => ["attrs", "vis", "union_token", "ident", "generics", "fields"],
-        }
-        .map(String::from)
-        .into()
-    }
-
     fn validate(&mut self) -> syn::Result<()> {
-        let legal_fields = self.legal_fields();
-
         if let syn::Fields::Named(ref fields) = self.data.fields {
-            let fields: HashSet<_> = fields
-                .named
-                .iter()
-                .filter_map(|f| f.ident.as_ref())
-                .map(|f| f.to_string())
-                .collect();
-
-            if let Some(ident) = fields.difference(&legal_fields).next() {
-                return Err(Error::new(
-                    ident.span(),
-                    format!("Unsupported field `{}`", ident),
-                ));
-            }
-
-            self.used_fields = fields.intersection(&legal_fields).cloned().collect();
+            self.used_fields = fields::validate_fields(self.kind, fields)?;
         } else {
             return Err(Error::new(
                 self.ident.span(),
@@ -93,41 +52,7 @@ impl SingleDerive {
             Kind::Union => quote!(::harled::syn::Data::Union(s)),
         };
 
-        let construct = used_fields
-            .into_iter()
-            .fold(quote!(), |mut construct, field| {
-                construct.extend(match field.as_str() {
-                    "attrs" => quote! {
-                        attrs: ast.attrs,
-                    },
-                    "vis" => quote! {
-                        vis: ast.vis,
-                    },
-                    "struct_token" => quote! {
-                        struct_token: s.struct_token,
-                    },
-                    "enum_token" => quote! {
-                        enum_token: s.enum_token,
-                    },
-                    "union_token" => quote! {
-                        union_token: s.union_token,
-                    },
-                    "ident" => quote! {
-                        ident: ast.ident,
-                    },
-                    "generics" => quote! {
-                        generics: ast.generics,
-                    },
-                    "fields" => quote! {
-                        fields: s.fields,
-                    },
-                    "variants" => quote! {
-                        variants: s.variants.into_iter().collect(),
-                    },
-                    _ => unreachable!(),
-                });
-                construct
-            });
+        let construct = fields::construct_fields(used_fields);
 
         quote! {
             impl ::harled::FromDeriveInput for #ident {

--- a/macro/src/single_derive.rs
+++ b/macro/src/single_derive.rs
@@ -52,7 +52,7 @@ impl SingleDerive {
             Kind::Union => quote!(::harled::syn::Data::Union(s)),
         };
 
-        let construct = fields::construct_fields(used_fields);
+        let construct = fields::construct_fields(&used_fields);
 
         quote! {
             impl ::harled::FromDeriveInput for #ident {


### PR DESCRIPTION
Allow enums deriving `FromDeriveInput` to use variants with named fields. Named fields are treated just like a struct deriving `FromDeriveInput` for the given kind.