### PR TITLE
Allow combinations of `Kind`s on structs

### DIFF
--- a/core/src/kind.rs
+++ b/core/src/kind.rs
@@ -24,3 +24,11 @@ impl TryFrom<syn::Ident> for Kind {
         value.to_string().parse()
     }
 }
+use syn::parse::{Parse, ParseStream};
+impl Parse for Kind {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        syn::Ident::parse(input)?
+            .try_into()
+            .map_err(|e| syn::Error::new(input.span(), format!("{:?}", e)))
+    }
+}

--- a/macro/src/combo.rs
+++ b/macro/src/combo.rs
@@ -1,0 +1,46 @@
+use crate::Kind;
+use proc_macro2::{TokenStream, TokenTree};
+use std::ops::Deref;
+use syn::{
+    parse::{Parse, ParseStream, Peek, Result},
+    punctuated::Punctuated,
+    Token,
+};
+
+#[derive(Default)]
+pub(crate) struct ComboKind(Punctuated<Kind, syn::Token![|]>);
+
+fn parse_until<E: Peek>(input: ParseStream, end: E) -> Result<TokenStream> {
+    let mut tokens = TokenStream::new();
+    while !input.is_empty() && !input.peek(end) {
+        let next: TokenTree = input.parse()?;
+        tokens.extend(Some(next));
+    }
+    Ok(tokens)
+}
+
+impl Parse for ComboKind {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut out = Self::default();
+
+        let first = parse_until(input, Token![|])?;
+        out.0.push_value(syn::parse2(first)?);
+
+        while input.peek(Token![|]) {
+            out.0.push_punct(input.parse()?);
+
+            let next = parse_until(input, Token![|])?;
+            out.0.push_value(syn::parse2(next)?);
+        }
+
+        Ok(out)
+    }
+}
+
+impl Deref for ComboKind {
+    type Target = Punctuated<Kind, Token![|]>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/macro/src/fields.rs
+++ b/macro/src/fields.rs
@@ -28,7 +28,7 @@ fn legal_fields(kind: Kind) -> HashSet<String> {
     .into()
 }
 
-pub fn validate_fields(kind: Kind, fields: &syn::FieldsNamed) -> syn::Result<Vec<String>> {
+pub fn validate_fields(kind: Kind, fields: &syn::FieldsNamed) -> syn::Result<HashSet<String>> {
     let legal_fields = legal_fields(kind);
 
     let fields: HashSet<_> = fields
@@ -45,43 +45,41 @@ pub fn validate_fields(kind: Kind, fields: &syn::FieldsNamed) -> syn::Result<Vec
         ));
     }
 
-    Ok(fields.intersection(&legal_fields).cloned().collect())
+    Ok(&fields & &legal_fields)
 }
 
-pub fn construct_fields(used_fields: &Vec<String>) -> TokenStream {
-    used_fields
-        .into_iter()
-        .fold(quote!(), |mut construct, field| {
-            construct.extend(match field.as_str() {
-                "attrs" => quote! {
-                    attrs: ast.attrs,
-                },
-                "vis" => quote! {
-                    vis: ast.vis,
-                },
-                "struct_token" => quote! {
-                    struct_token: s.struct_token,
-                },
-                "enum_token" => quote! {
-                    enum_token: s.enum_token,
-                },
-                "union_token" => quote! {
-                    union_token: s.union_token,
-                },
-                "ident" => quote! {
-                    ident: ast.ident,
-                },
-                "generics" => quote! {
-                    generics: ast.generics,
-                },
-                "fields" => quote! {
-                    fields: s.fields,
-                },
-                "variants" => quote! {
-                    variants: s.variants.into_iter().collect(),
-                },
-                _ => unreachable!(),
-            });
-            construct
-        })
+pub fn construct_fields(used_fields: &HashSet<String>) -> TokenStream {
+    used_fields.iter().fold(quote!(), |mut construct, field| {
+        construct.extend(match field.as_str() {
+            "attrs" => quote! {
+                attrs: ast.attrs,
+            },
+            "vis" => quote! {
+                vis: ast.vis,
+            },
+            "struct_token" => quote! {
+                struct_token: s.struct_token,
+            },
+            "enum_token" => quote! {
+                enum_token: s.enum_token,
+            },
+            "union_token" => quote! {
+                union_token: s.union_token,
+            },
+            "ident" => quote! {
+                ident: ast.ident,
+            },
+            "generics" => quote! {
+                generics: ast.generics,
+            },
+            "fields" => quote! {
+                fields: s.fields,
+            },
+            "variants" => quote! {
+                variants: s.variants.into_iter().collect(),
+            },
+            _ => unreachable!(),
+        });
+        construct
+    })
 }

--- a/macro/src/multi_derive.rs
+++ b/macro/src/multi_derive.rs
@@ -4,13 +4,13 @@ use crate::{
 };
 use proc_macro2::TokenStream;
 use quote::quote;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use syn::{spanned::Spanned, Error};
 
 #[derive(PartialEq, Eq)]
 enum DeriveVariant {
     Type(syn::Type),
-    StructLike(Vec<String>),
+    StructLike(HashSet<String>),
 }
 
 pub struct MultiDerive {

--- a/macro/src/single_derive.rs
+++ b/macro/src/single_derive.rs
@@ -1,17 +1,18 @@
-use crate::{fields, Kind};
+use crate::{fields, ComboKind, Kind};
 use proc_macro2::TokenStream;
 use quote::quote;
+use std::collections::HashSet;
 use syn::Error;
 
 pub(crate) struct SingleDerive {
-    kind: Kind,
+    kind: ComboKind,
     ident: syn::Ident,
     data: syn::DataStruct,
-    used_fields: Vec<String>,
+    used_fields: HashSet<String>,
 }
 
 impl SingleDerive {
-    pub(crate) fn new(kind: Kind, input: syn::DeriveInput) -> Self {
+    pub(crate) fn new(kind: ComboKind, input: syn::DeriveInput) -> Self {
         Self {
             kind,
             ident: input.ident,
@@ -20,19 +21,34 @@ impl SingleDerive {
             } else {
                 panic!("SingleDerive was passed non-struct")
             },
-            used_fields: vec![],
+            used_fields: HashSet::new(),
         }
     }
 
     fn validate(&mut self) -> syn::Result<()> {
         if let syn::Fields::Named(ref fields) = self.data.fields {
-            self.used_fields = fields::validate_fields(self.kind, fields)?;
+            self.used_fields = self
+                .kind
+                .iter()
+                .map(|kind| fields::validate_fields(*kind, fields))
+                .try_fold(HashSet::<String>::new(), |hs, fields| {
+                    if hs.is_empty() {
+                        fields
+                    } else {
+                        Ok(&hs & &fields?)
+                    }
+                })?;
+
+            if self.kind.len() > 1 {
+                //NOTE currently usupported due to Structs and Unions having different field types
+                self.used_fields.remove("fields");
+            }
         } else {
             return Err(Error::new(
                 self.ident.span(),
                 "FromDeriveInput only support named struct fields",
             ));
-        };
+        }
 
         Ok(())
     }
@@ -46,13 +62,30 @@ impl SingleDerive {
             ident, used_fields, ..
         } = self;
 
-        let branch = match self.kind {
-            Kind::Struct => quote!(::harled::syn::Data::Struct(s)),
-            Kind::Enum => quote!(::harled::syn::Data::Enum(s)),
-            Kind::Union => quote!(::harled::syn::Data::Union(s)),
-        };
-
         let construct = fields::construct_fields(&used_fields);
+
+        let branches = self
+            .kind
+            .iter()
+            .map(|kind| match kind {
+                Kind::Struct => quote! {
+                    ::harled::syn::Data::Struct(s)=> Ok(Self{
+                        #construct
+                    }),
+                },
+                Kind::Enum => quote! {
+                    ::harled::syn::Data::Enum(s)=> Ok(Self{
+                        #construct
+                    }),
+                },
+                Kind::Union => quote! {
+                    ::harled::syn::Data::Union(s)=> Ok(Self{
+                        #construct
+                    }),
+                },
+            })
+            .reduce(|l, r| quote!(#l #r))
+            .unwrap();
 
         quote! {
             impl ::harled::FromDeriveInput for #ident {
@@ -61,9 +94,7 @@ impl SingleDerive {
                     use ::harled::syn::spanned::Spanned;
                     let ast = input.input();
                     match ast.data {
-                        #branch => Ok(Self{
-                            #construct
-                        }),
+                        #branches
                         _ => Err(::harled::syn::Error::new(
                             ast.span(),
                             "#[derive(FromDeriveInput)] with attribute can only be used on structs"


### PR DESCRIPTION
Structs can now support combinations of `Kind`s with `#[harled(Kind | Kind)]`, structs that support more than one `Kind` may only use fields shared between all supported `Kind`s

Due to a type difference in `syn::DataStructs` and `syn::DataUnion` the field `fields` is currently unsupported for combined structs